### PR TITLE
Made the plugin compatible with publishing

### DIFF
--- a/cmsplugin_gallery/models.py
+++ b/cmsplugin_gallery/models.py
@@ -14,6 +14,9 @@ TEMPLATE_CHOICES = localdata.TEMPLATE_CHOICES
 
 class GalleryPlugin(CMSPlugin):
 
+    def copy_relations(self, oldinstance):
+        self.image_set = oldinstance.image_set.all()
+
     template = models.CharField(max_length=255,
                                 choices=TEMPLATE_CHOICES,
                                 default='cmsplugin_gallery/gallery.html',


### PR DESCRIPTION
Problem: when I publish a page with a gallery, the gallery is emptied.

Cause: CMS Plugin models that depend on a foreign key or many-to-many to work (either direction) need to have a copy_relations() method.
