### PR TITLE
Fixing the copy mechanism.

### DIFF
--- a/cmsplugin_gallery/models.py
+++ b/cmsplugin_gallery/models.py
@@ -15,7 +15,15 @@ TEMPLATE_CHOICES = localdata.TEMPLATE_CHOICES
 class GalleryPlugin(CMSPlugin):
 
     def copy_relations(self, oldinstance):
-        self.image_set = oldinstance.image_set.all()
+        for img in oldinstance.image_set.all():
+            new_img = Image()
+            new_img.gallery=self
+            new_img.src = img.src
+            new_img.src_height = img.src_height
+            new_img.src_width = img.src_width
+            new_img.title = img.title
+            new_img.alt = img.alt
+            new_img.save()
 
     template = models.CharField(max_length=255,
                                 choices=TEMPLATE_CHOICES,


### PR DESCRIPTION
This pull request addresses the issue discussed in the following bug:

https://github.com/centralniak/cmsplugin_gallery/issues/11

It hit me when using Zinnia to create a gallery plugin instance.  The instance ended up being moved from the 'draft' to the 'published' instance of the page.  When I went back to edit the plugin, it was gone.
