### PR TITLE
get_media_path: add fallback to allow using Galleries with standalone placeholder

### DIFF
--- a/cmsplugin_gallery/models.py
+++ b/cmsplugin_gallery/models.py
@@ -30,7 +30,7 @@ class GalleryPlugin(CMSPlugin):
 
     template = models.CharField(max_length=255,
                                 choices=TEMPLATE_CHOICES,
-                                default='cmsplugin_gallery/gallery.html',
+                                default=TEMPLATE_CHOICES[0][0],
                                 editable=len(TEMPLATE_CHOICES) > 1)
 
     def __unicode__(self):


### PR DESCRIPTION
Hi, I am using cmsplugin_gallery with placeholderfields in my models, so I added this code from CMSPluginbase to cope with pages not existing. 
Also, I do not wish to use the default template, so instead of having its name hardcoded, I modified the model to default to the first template available.
Cheers.
