### PR TITLE
Adjuste to python3.5

### DIFF
--- a/cmsplugin_gallery/admin.py
+++ b/cmsplugin_gallery/admin.py
@@ -1,6 +1,6 @@
 from inline_ordering.admin import OrderableStackedInline
-import forms
-import models
+from . import forms
+from . import models
 
 
 class ImageInline(OrderableStackedInline):

--- a/cmsplugin_gallery/cms_plugins.py
+++ b/cmsplugin_gallery/cms_plugins.py
@@ -2,8 +2,8 @@ from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 from django.utils.translation import ugettext_lazy as _
 
-import admin
-import models
+from . import admin
+from . import models
 
 
 class CMSGalleryPlugin(CMSPluginBase):

--- a/cmsplugin_gallery/models.py
+++ b/cmsplugin_gallery/models.py
@@ -10,7 +10,7 @@ from inline_ordering.models import Orderable
 from django.utils.deconstruct import deconstructible
 from django.db import connection
 
-import utils
+from . import utils
 
 localdata = threading.local()
 localdata.TEMPLATE_CHOICES = utils.autodiscover_templates()


### PR DESCRIPTION
In python3.5 the syntax of import modules in local folders is different.

Ex:

from . import module
